### PR TITLE
Copy a fixed version of the opengl-bitmap package into graphics-drawingcombinators

### DIFF
--- a/Graphics/DrawingCombinators.hs
+++ b/Graphics/DrawingCombinators.hs
@@ -81,9 +81,9 @@ where
 import Graphics.DrawingCombinators.Affine
 import Control.Applicative (Applicative(..), liftA2, (*>), (<$>))
 import Data.Monoid (Monoid(..), Any(..))
+import qualified Graphics.DrawingCombinators.Bitmap as Bitmap
 import qualified Graphics.Rendering.OpenGL.GL as GL
 import qualified Codec.Image.STB as Image
-import qualified Data.Bitmap.OpenGL as Bitmap
 import System.IO.Unsafe (unsafePerformIO)  -- for pure textWidth
 
 #ifdef LAME_FONTS

--- a/Graphics/DrawingCombinators/Bitmap.hs
+++ b/Graphics/DrawingCombinators/Bitmap.hs
@@ -1,0 +1,88 @@
+-- | OpenGL support for Data.Bitmap
+
+{- Copied from the bitmap-opengl package because maintainer is
+   unresponsive about bug-fixes/uploads -}
+{- Copyright: (c) 2009 Balazs Komuves -}
+
+{-# LANGUAGE ScopedTypeVariables #-}
+module Graphics.DrawingCombinators.Bitmap
+  ( makeSimpleBitmapTexture
+  , makeTextureFromBitmap
+  , texImageFromBitmap
+  ) where
+
+--------------------------------------------------------------------------------
+
+import Data.Bitmap
+
+import Graphics.Rendering.OpenGL
+
+--------------------------------------------------------------------------------
+
+-- OpenGL data type
+dataType :: PixelComponent t => t -> DataType
+dataType t = case pixelComponentType t of
+  PctWord8  -> UnsignedByte
+  PctWord16 -> UnsignedShort
+  PctWord32 -> UnsignedInt
+  PctFloat  -> Float
+
+--------------------------------------------------------------------------------
+
+-- | This function guesses the pixel format from the number of channels:
+-- 
+-- * 1 ~> Alpha
+--
+-- * 2 ~> Luminance, Alpha
+--
+-- * 3 ~> RGB
+--
+-- * 4 ~> RGBA
+--
+-- For more control, use 'makeTextureFromBitmap'.
+makeSimpleBitmapTexture :: forall t. PixelComponent t => Bitmap t -> IO TextureObject
+makeSimpleBitmapTexture bm = do
+  let (pf,pif) = case pixelComponentType (undefined::t) of 
+        PctWord8 -> case bitmapNChannels bm of
+          1 -> (Alpha, Alpha8)
+          2 -> (LuminanceAlpha, Luminance8Alpha8)
+          3 -> (RGB, RGB8)
+          4 -> (RGBA, RGBA8)  
+          n -> error $ "Invalid bitmap channel count: " ++ show n
+        _ -> case bitmapNChannels bm of
+          1 -> (Alpha, Alpha')
+          2 -> (LuminanceAlpha, LuminanceAlpha')
+          3 -> (RGB, RGB')
+          4 -> (RGBA, RGBA')  
+          n -> error $ "Invalid bitmap channel count: " ++ show n
+  makeTextureFromBitmap bm Nothing 0 pf pif 0 
+  
+-- | Creates a new OpenGL texture from a bitmap
+makeTextureFromBitmap 
+  :: PixelComponent t 
+  => Bitmap t -> Maybe CubeMapTarget -> Level -> PixelFormat -> PixelInternalFormat -> Border -> IO TextureObject
+makeTextureFromBitmap bm cubemap level pf pif border = do
+  old_binding <- get (textureBinding Texture2D)
+  [tex] <- genObjectNames 1 
+  textureBinding Texture2D $= Just tex 
+  textureFilter Texture2D $= ((Linear',Nothing),Linear')
+  texImageFromBitmap bm cubemap level pf pif border   
+  textureBinding Texture2D $= old_binding
+  return tex
+
+texImageFromBitmap
+  :: forall t. PixelComponent t 
+  => Bitmap t -> Maybe CubeMapTarget -> Level -> PixelFormat -> PixelInternalFormat -> Border -> IO ()
+texImageFromBitmap bm cubemap level pf pif border = do
+  withBitmap bm $ \(width,height) _nchn _pad ptr -> do
+--    old_rowlength <- get (rowLength Unpack)
+    old_alignment <- get (rowAlignment Unpack)
+    let pdata = PixelData pf (dataType (undefined::t)) ptr  
+        size = TextureSize2D (fromIntegral width) (fromIntegral height) 
+--    rowLength Unpack $= fromIntegral (bitmapPaddedRowSizeInBytes bm)
+    rowAlignment Unpack $= fromIntegral (bitmapRowAlignment bm)
+    texImage2D cubemap NoProxy level pif size border pdata
+--    rowLength Unpack $= old_rowlength 
+    rowAlignment Unpack $= old_alignment
+  
+--------------------------------------------------------------------------------

--- a/graphics-drawingcombinators.cabal
+++ b/graphics-drawingcombinators.cabal
@@ -20,8 +20,9 @@ Flag ftgl
     Description: Does the system have FTGL, thus we could use not sucky fonts
 
 Library
-    Build-Depends: base == 4.*, containers, OpenGL >= 2.4 && < 2.6, stb-image == 0.2.*, bitmap-opengl == 0.0.*
+    Build-Depends: base == 4.*, containers, OpenGL >= 2.4 && < 2.6, stb-image == 0.2.*, bitmap >= 0.0.2
     Exposed-Modules: Graphics.DrawingCombinators, Graphics.DrawingCombinators.Affine
+    Other-Modules: Graphics.DrawingCombinators.Bitmap
     ghc-options : -Wall 
     Ghc-Prof-Options:  -prof -auto-all
 


### PR DESCRIPTION
Unfortunately, Balazs Komuves has not been maintaining the set of bitmap packages in a while, and they've not built properly on newer GHCs/platforms versions.

Tired of waiting for a fix, this commit is a temporary solution -- that inlines the package with the trivial fix. The package is BSD-licensed, and a copyright/copy notice was added, so this should not be a problem.

This can be reverted when the bitmap-opengl package builds again.

Please upload a new graphics-drawingcombinators version to hackage, too, so it becomes usable again!
