### PR TITLE
Use ftgl "buffer fonts" rather than "texture fonts" to avoid crashes …

### DIFF
--- a/src/Graphics/DrawingCombinators.hs
+++ b/src/Graphics/DrawingCombinators.hs
@@ -393,7 +393,7 @@ renderText font str = do
 -- http://hackage.haskell.org/package/base-4.8.0.0/docs/System-Mem-Weak.html#v:addFinalizer
 openFont :: FilePath -> IO Font
 openFont path = do
-    font <- FTGL.createTextureFont path
+    font <- FTGL.createBufferFont path
     addFinalizer font (FTGL.destroyFont font)
     _ <- FTGL.setFontFaceSize font 72 72
     return $ Font font


### PR DESCRIPTION
…in unsafePerformIO

Previously, graphics-drawingcombinators could crash when using threads,
and textWidth was called on a different thread than the OpenGL drawing thread.

With buffer fonts these crash do not happen because FTGL.getFontAdvance does not rely on the OpenGL context.
Buffer fonts also seem like an overall good choice according to: http://ftgl.sourceforge.net/docs/html/ftgl-tutorial.html#texture

Crash stack trace (before this fix):
0   libGL.dylib                   	0x00007fff949ca840 glPushClientAttrib + 15
1   libftgl.2.dylib               	0x000000010549e2a9 FTTextureGlyphImpl::FTTextureGlyphImpl(FT_GlyphSlotRec_*, int, int, int, int, int) + 249 (FTTextureGlyph.cpp:110)
2   libftgl.2.dylib               	0x000000010549e0d1 FTTextureGlyph::FTTextureGlyph(FT_GlyphSlotRec_*, int, int, int, int, int) + 81 (FTTextureGlyph.cpp:64)
3   libftgl.2.dylib               	0x00000001054a4d1b FTTextureFontImpl::MakeGlyphImpl(FT_GlyphSlotRec_*) + 1435 (FTTextureFont.cpp:165)
4   libftgl.2.dylib               	0x00000001054a026c FTFontImpl::CheckGlyph(unsigned int) + 92 (FTFont.cpp:540)
5   libftgl.2.dylib               	0x000000010549fdd1 FTFontImpl::Advance(char const*, int, FTPoint) + 145 (FTFont.cpp:451)
6   libftgl.2.dylib               	0x000000010549ecc0 FTFont::Advance(char const*, int, FTPoint) + 48 (FTFont.cpp:181)
7   libftgl.2.dylib               	0x00000001054a111f ftglGetFontAdvance + 79 (FTFontGlue.cpp:232)
8   lamdu                         	0x0000000101a56526 c7rr_info + 46
9   ???                           	0x00007fe3aa67a3b0 0 + 140615793222576

Tested with:
OS X 10.10.3
GHC 7.8.4
FTGL (Haskell bindings) 2.1
FTGL (system library) 2.1.3-rc5
Lamdu (https://github.com/Peaker/lamdu/commit/77b80ed0bc0ea77b9633e208f95d52d171b744ed)