### PR TITLE
Bump OpenGL dependency to allow >= 2.9 && < 3.1

### DIFF
--- a/graphics-drawingcombinators.cabal
+++ b/graphics-drawingcombinators.cabal
@@ -24,7 +24,7 @@ Flag ftgl
     Description: Does the system have FTGL, thus we could use not sucky fonts
 
 Library
-    Build-Depends: base == 4.*, OpenGL >= 2.9, stb-image == 0.2.*, bitmap >= 0.0.2, bitmap-opengl >= 0.0.1.5
+    Build-Depends: base == 4.*, OpenGL >= 2.9 && < 3.1, stb-image == 0.2.*, bitmap >= 0.0.2, bitmap-opengl >= 0.0.1.5
     hs-Source-Dirs: src
     Exposed-Modules: Graphics.DrawingCombinators, Graphics.DrawingCombinators.Affine
     ghc-options: -Wall


### PR DESCRIPTION
Example builds and runs (four spinning circles with the png embedded and Hello World written in the font.)

Fixes #15 